### PR TITLE
Resolve static analysis issue

### DIFF
--- a/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
+++ b/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
@@ -137,11 +137,11 @@
                 }
             }
         }
-    }
-    
-    if (_movedSectionNames.count + _insertedSectionNames.count + _deletedSectionNames.count
-        + _movedItems.count + _insertedItems.count + _deletedItems.count + _modifiedItems.count > 0) {
-        _hasChanges = YES;
+
+        if (_movedSectionNames.count + _insertedSectionNames.count + _deletedSectionNames.count
+            + _movedItems.count + _insertedItems.count + _deletedItems.count + _modifiedItems.count > 0) {
+            _hasChanges = YES;
+        }
     }
     
     return self;


### PR DESCRIPTION
This resolves the following issue found via clang static analysis:

Access to instance variable '_movedSectionNames' results in a
dereference of a null pointer (loaded from variable 'self')

The block of code in question that has been moved was outside the if
block that tests that self is in fact not nil.