### PR TITLE
Modified Comparator

### DIFF
--- a/TLIndexPathTools/Data Model/TLIndexPathUpdates.h
+++ b/TLIndexPathTools/Data Model/TLIndexPathUpdates.h
@@ -36,7 +36,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Creating updates
 
+/**
+ * Takes two versions of a data model and computes the changes, i.e. the inserts,
+ * moves, deletes and modifications.
+ *
+ * @param oldDataModel                The previous data model.
+ * @param updatedDataModel            The updated data model.
+ * @return A newly initialized TLIndexPathUpdates object.
+ * @see initWithOldDataModel:updatedDataModel:modificationComparatorBlock:
+ */
 - (id)initWithOldDataModel:(TLIndexPathDataModel * __nullable)oldDataModel updatedDataModel:(TLIndexPathDataModel * __nullable)updatedDataModel;
+
+/**
+ * Takes two versions of a data model and computes the changes, i.e. the inserts,
+ * moves, deletes and modifications.
+ *
+ * @param oldDataModel                The previous data model.
+ * @param updatedDataModel            The updated data model.
+ * @param modificationComparatorBlock A block which is used to determine if an old data model object has been modified. This is passed two objects and should return `NO` if the objects are to be considered the same, or `YES` if modifications have occurred. This block can be `nil`.
+ *
+ * @return A newly initialized TLIndexPathUpdates object.
+ * @see initWithOldDataModel:updatedDataModel:
+ */
 - (id)initWithOldDataModel:(TLIndexPathDataModel * __nullable)oldDataModel updatedDataModel:(TLIndexPathDataModel * __nullable)updatedDataModel modificationComparatorBlock:(BOOL(^ __nullable)(id item1, id item2))modificationComparatorBlock;
 
 #pragma mark - Performing batch updates

--- a/TLIndexPathTools/Data Model/TLIndexPathUpdates.h
+++ b/TLIndexPathTools/Data Model/TLIndexPathUpdates.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Creating updates
 
 - (id)initWithOldDataModel:(TLIndexPathDataModel * __nullable)oldDataModel updatedDataModel:(TLIndexPathDataModel * __nullable)updatedDataModel;
+- (id)initWithOldDataModel:(TLIndexPathDataModel * __nullable)oldDataModel updatedDataModel:(TLIndexPathDataModel * __nullable)updatedDataModel modificationComparatorBlock:(BOOL(^ __nullable)(id item1, id item2))modificationComparatorBlock;
 
 #pragma mark - Performing batch updates
 

--- a/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
+++ b/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
@@ -37,6 +37,11 @@
 
 - (id)initWithOldDataModel:(TLIndexPathDataModel *)oldDataModel updatedDataModel:(TLIndexPathDataModel *)updatedDataModel
 {
+    return [self initWithOldDataModel:oldDataModel updatedDataModel:updatedDataModel modificationComparatorBlock:nil];
+}
+
+- (id)initWithOldDataModel:(TLIndexPathDataModel * __nullable)oldDataModel updatedDataModel:(TLIndexPathDataModel * __nullable)updatedDataModel modificationComparatorBlock:(BOOL(^ __nullable)(id item1, id item2))modificationComparatorBlock
+{
     if (self = [super init]) {
         
         _hasChanges = NO;
@@ -126,7 +131,14 @@
         for (id item in updatedDataModel.items) {
             id oldItem = [oldDataModel currentVersionOfItem:item];
             if (oldItem) {
-                if (![oldItem isEqual:item]) {
+                BOOL modified = NO;
+                if (modificationComparatorBlock) {
+                    modified = modificationComparatorBlock(item, oldItem);
+                } else {
+                    modified = ![oldItem isEqual:item];
+                }
+                
+                if (modified) {
                     [modifiedItems addObject:item];
                 }
             } else {


### PR DESCRIPTION
A relatively minor modification which allows for the `TLIndexPathUpdates` object to be initialized with a block which can be used to determine if two objects are to be considered modified. This allows for comparisons to be made by a user supplied block which can perform more detailed modification analysis than `isEqual:`, if desired.