### PR TITLE
Changes reloading of modified cells to just reload all the visible cells

### DIFF
--- a/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
+++ b/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
@@ -183,7 +183,15 @@
         //nice, but it is better than a crash.
 
         if (self.modifiedItems.count && self.updateModifiedItems) {
-            [tableView reloadRowsAtIndexPaths:tableView.indexPathsForVisibleRows withRowAnimation:animation];
+
+            NSMutableArray *indexPaths = [[NSMutableArray alloc] init];
+            for (id item in self.modifiedItems) {
+                NSIndexPath *indexPath = [self.updatedDataModel indexPathForItem:item];
+                [indexPaths addObject:indexPath];
+            }
+
+            NSArray *visibleModifiedIndexPaths = [self intersectArray:tableView.indexPathsForVisibleRows withArray:indexPaths];
+            [tableView reloadRowsAtIndexPaths:visibleModifiedIndexPaths withRowAnimation:animation];
         }
 
         if (completion) {
@@ -410,6 +418,14 @@
 {
     _modifiedItems = [modifiedItems copy];
     self.hasChanges = self.hasChanges || _modifiedItems.count != 0;
+}
+
+- (NSArray *)intersectArray:(NSArray *)firstArray withArray:(NSArray *)secondArray
+{
+    NSMutableSet *set1 = [NSMutableSet setWithArray: firstArray];
+    NSSet *set2 = [NSSet setWithArray: secondArray];
+    [set1 intersectSet: set2];
+    return [set1 allObjects];
 }
 
 @end

--- a/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
+++ b/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
@@ -181,16 +181,11 @@
         //because, otherwise, the table view will throw an exception about
         //duplicate animations being applied to cells. This doesn't always look
         //nice, but it is better than a crash.
-        
+
         if (self.modifiedItems.count && self.updateModifiedItems) {
-            NSMutableArray *indexPaths = [[NSMutableArray alloc] init];
-            for (id item in self.modifiedItems) {
-                NSIndexPath *indexPath = [self.updatedDataModel indexPathForItem:item];
-                [indexPaths addObject:indexPath];
-            }
-            [tableView reloadRowsAtIndexPaths:indexPaths withRowAnimation:animation];
+            [tableView reloadRowsAtIndexPaths:tableView.indexPathsForVisibleRows withRowAnimation:animation];
         }
-        
+
         if (completion) {
             completion(YES);
         }


### PR DESCRIPTION
This shouldn't be too much of a performance hit and simplifies the whole thing dramatically to avoid crashes that occured from time to time when trying to reload cells at indexpaths that were not existent.

What do you think?